### PR TITLE
fix: `dt claim claim` --dry-run default True

### DIFF
--- a/dtcli/args/claim.py
+++ b/dtcli/args/claim.py
@@ -23,8 +23,8 @@ CLAIM = dtcli.parser.CmdArgs([
     dtcli.parser.Arg(
         key='dry_run',
         flags=['--dry-run'],
+        metavar='',
         format=dtcli.format.to_bool,
-        action='store_true',
     ),
 ])
 


### PR DESCRIPTION
Propagated [this](https://github.com/disruptive-technologies/python-client/pull/117) fix from the python client.